### PR TITLE
Enhancement to DB variables in config.php and db.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -6,20 +6,15 @@
     
     // mysql || sqlite || pgsql
     $database_type = "mysql";
-    // Mysql Database
-    $db['mysql']['host'] ="localhost";
-    $db['mysql']['database']="secretsanta";
-    $db['mysql']['username']="root";
-    $db['mysql']['password']="";
+
+    // Mysql & Pgsql Database
+    $db[$database_type]['host'] ="localhost";
+    $db[$database_type]['database']="secretsanta";
+    $db[$database_type]['username']="root";
+    $db[$database_type]['password']="";
     
     // Sqlite Database
-    $db['sqlite']['path'] = "";
-    
-    // Pgsql Database
-    $db['pgsql']['host'] ="localhost";
-    $db['pgsql']['database']="secretsanta";
-    $db['pgsql']['username']="root";
-    $db['pgsql']['password']="";
+    $db[$database_type]['path'] = "";
 
 
   /*    SMTP Outgoing Mail Settings

--- a/function/db.php
+++ b/function/db.php
@@ -10,17 +10,15 @@
   function connectDB(){
     //database connection credentials
     global $db;
+    global $database_type;
 
     //try to connect to the database - throw error if unsuccessful
     try {
-      if($database_type == "mysql"){
-        $conn = new PDO("mysql:host=$db['mysql']['host'];dbname=$db['mysql']['database']", $db['mysql']['username'], $db['mysql']['password']);  
+      if($database_type != "sqlite"){
+        $conn = new PDO("{$database_type}:host={$db[$database_type]['host']};dbname={$db[$database_type]['database']}", $db[$database_type]['username'], $db[$database_type]['password']);  
       }
-      else if($database_type == "sqlite"){
-        $con = new PDO('sqlite:'.$db['sqlite']['path']);
-      }
-      else if($database_type == "pgsql"){
-        $con = new PDO('pgsql:host='.$db['pgsql']['host'].';dbname='.$db['pgsql']['database'].';user='.$db['pgsql']['username'].';password='.$db['pgsql']['password']);
+      else {
+        $con = new PDO("{$database_type}:".$db[$database_type]['path']);
       }
 
       $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
**config.php**
mysql and pgsql have the same (host, database, username and password) so no need to write the block twice and replace it with the variable `$database_type`

**function/db.php**
defined `$database_type` as global, and changed the `$conn` accordingly 